### PR TITLE
Add missing public new function for Timer16

### DIFF
--- a/src/modules/timer/timer16.rs
+++ b/src/modules/timer/timer16.rs
@@ -155,7 +155,7 @@ pub struct Timer16Setup<T: Timer16> {
 
 impl<T: Timer16> Timer16Setup<T> {
     #[inline]
-    fn new() -> Self {
+    pub fn new() -> Self {
         Timer16Setup {
             a: RegisterBits::zero(),
             b: RegisterBits::zero(),


### PR DESCRIPTION
This function is public for `Timer8`