### PR TITLE
Make the std-stub optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,11 @@ build = "core_generator/build.rs"
 
 keywords = ["avr", "arduino", "uno"]
 
+[features]
+default = ["avr-std-stub"]
+
 [dependencies]
-avr-std-stub = "1.0"
+avr-std-stub = { version = "1.0", optional = true }
 target-cpu-macro = "0.1"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 
 #![no_std]
 
-extern crate avr_std_stub;
-
 pub use self::register::{Register, RegisterBits, RegisterValue};
 pub use self::pin::{DataDirection, Pin};
 


### PR DESCRIPTION
This allows people to provide their own `panic_handler`

Closes #19 