### PR TITLE
Make the 'avr-std-stub' dependency optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 
 #![no_std]
 
+#[cfg(feature = "avr-std-stub")] extern crate avr_std_stub;
+
 pub use self::register::{Register, RegisterBits, RegisterValue};
 pub use self::pin::{DataDirection, Pin};
 


### PR DESCRIPTION
This way, downstream users may user their own panic handlers and
exception handling personality functions if they desire.