### PR TITLE
Fix build: Use the new rust asm! available in rustc 1.63.0-nightly

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -2,6 +2,7 @@
 
 use core::prelude::v1::*;
 use core::marker::PhantomData;
+use core::arch::asm;
 
 /// Helper struct that automatically restores interrupts
 /// on drop.
@@ -22,7 +23,7 @@ pub fn without_interrupts<F, T>(f: F) -> T
 impl DisableInterrupts {
     #[inline(always)]
     pub fn new() -> DisableInterrupts {
-        unsafe { llvm_asm!("CLI") }
+        unsafe { asm!("cli") }
         DisableInterrupts(PhantomData)
     }
 }
@@ -30,7 +31,7 @@ impl DisableInterrupts {
 impl Drop for DisableInterrupts {
     #[inline(always)]
     fn drop(&mut self) {
-        unsafe { llvm_asm!("SEI") }
+        unsafe { asm!("sei") }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 //! Definitions of register addresses and bits within those registers
 
-#![feature(llvm_asm)]
-#![feature(const_fn)]
+#![feature(asm_experimental_arch)]
 #![feature(associated_type_defaults)]
 #![feature(lang_items)]
-#![feature(unwind_attributes)]
 #![feature(proc_macro_hygiene)]
 
 #![no_std]


### PR DESCRIPTION
The old llvm_asm! has been removed. Therefore, it doesn't compile
on new rustc anymore.

In addition to this, an updated avr-delay dependency is needed to compile successfully: https://github.com/avr-rust/delay/pull/18