### PR TITLE
RFC: Add API to suspend/restore interrupts ...

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -2,6 +2,7 @@
 
 use core::prelude::v1::*;
 use core::marker::PhantomData;
+use core::arch::asm;
 
 /// Helper struct that automatically restores interrupts
 /// on drop.
@@ -22,7 +23,7 @@ pub fn without_interrupts<F, T>(f: F) -> T
 impl DisableInterrupts {
     #[inline(always)]
     pub fn new() -> DisableInterrupts {
-        unsafe { llvm_asm!("CLI") }
+        unsafe { asm!("cli") }
         DisableInterrupts(PhantomData)
     }
 }
@@ -30,7 +31,7 @@ impl DisableInterrupts {
 impl Drop for DisableInterrupts {
     #[inline(always)]
     fn drop(&mut self) {
-        unsafe { llvm_asm!("SEI") }
+        unsafe { asm!("sei") }
     }
 }
 

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -3,21 +3,31 @@
 use core::prelude::v1::*;
 use core::marker::PhantomData;
 use core::arch::asm;
+use crate::cores::current::SREG;
+use crate::register::Register;
 
-/// Helper struct that automatically restores interrupts
+/// Helper struct that automatically enables interrupts
 /// on drop.
 struct DisableInterrupts(PhantomData<()>);
 
 /// Executes a closure, disabling interrupts until its completion.
 ///
-/// Restores interrupts after the closure has completed
+/// Unconditionally enables interrupts after the closure has completed
 /// execution.
 #[inline(always)]
-pub fn without_interrupts<F, T>(f: F) -> T
+pub fn with_irqs_disabled<F, T>(f: F) -> T
     where F: FnOnce() -> T
 {
     let _disabled = DisableInterrupts::new();
     f()
+}
+
+#[inline(always)]
+#[deprecated(note="Please use with_irqs_disabled instead")]
+pub fn without_interrupts<F, T>(f: F) -> T
+    where F: FnOnce() -> T
+{
+    with_irqs_disabled(f)
 }
 
 impl DisableInterrupts {
@@ -35,3 +45,34 @@ impl Drop for DisableInterrupts {
     }
 }
 
+/// Helper struct that automatically restores interrupts
+/// on drop.
+struct SuspendInterrupts(u8);
+
+/// Executes a closure, disabling interrupts until its completion.
+///
+/// Restores interrupts to the previous state after the closure has completed
+/// execution.
+#[inline(always)]
+pub fn with_irqs_suspended<F, T>(f: F) -> T
+    where F: FnOnce() -> T
+{
+    let _disabled = SuspendInterrupts::new();
+    f()
+}
+
+impl SuspendInterrupts {
+    #[inline(always)]
+    pub fn new() -> SuspendInterrupts {
+        let ret = SuspendInterrupts(SREG::read());
+        unsafe { asm!("cli") }
+        ret
+    }
+}
+
+impl Drop for SuspendInterrupts {
+    #[inline(always)]
+    fn drop(&mut self) {
+        SREG::write(self.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 //! Definitions of register addresses and bits within those registers
 
-#![feature(llvm_asm)]
-#![feature(const_fn)]
+#![feature(asm_experimental_arch)]
 #![feature(associated_type_defaults)]
 #![feature(lang_items)]
-#![feature(unwind_attributes)]
 #![feature(proc_macro_hygiene)]
 
 #![no_std]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,7 @@
 //! Re-exports commonly-used APIs that can be imported at once.
 
+pub use crate::interrupt::with_irqs_disabled;
+pub use crate::interrupt::with_irqs_suspended;
+#[allow(deprecated)]
+#[deprecated]
 pub use crate::interrupt::without_interrupts;
-


### PR DESCRIPTION
... similar to the current without_interrupts() helper.

What do you think about this?

I renamed the existing disable/enable API to with_irqs_disabled().
The new API for suspend/restore is with_irqs_suspended().
The old without_interrupts remains as deprecated alias.

I'm not so sure about the naming. Suggestions for better naming are welcome. :)

This is completely untested. Just for discussion.