### PR TITLE
regenerate-cores.sh: Enforce bash

### DIFF
--- a/regenerate-cores.sh
+++ b/regenerate-cores.sh
@@ -1,4 +1,4 @@
-#! /bin/sh -ea
+#! /bin/bash -ea
 
 set -o pipefail
 


### PR DESCRIPTION
Plain sh (like dash) doesn't support pipefail.